### PR TITLE
Make possible usage as a git submodule

### DIFF
--- a/QMaterialIcons.pri
+++ b/QMaterialIcons.pri
@@ -1,0 +1,34 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016 David Krepsky
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#/
+
+SOURCES += \
+    $$PWD/src/qmaterialicons.cpp
+
+HEADERS += \
+    $$PWD/src/qmaterialicons.h++
+
+RESOURCES += \
+    $$PWD/src/font.qrc
+
+INCLUDEPATH += \
+    $$PWD/src

--- a/README.md
+++ b/README.md
@@ -50,6 +50,16 @@ Another way is to put the files libQMaterialIcons.(lib or a) and qmaterialicons.
 
 Also, you can copy the header, source and resources to your project directory and include it directly inside your project.
 
+Using as a git submodule
+------------------------
+
+    # add QMaterialIcons as a git module
+    git submodule add https://github.com/DKrepsky/QMaterialIcons.git
+
+    # include it to your project file
+    include(QMaterialIcons/QMaterialIcons.pri)
+
+
 Build Instructions
 ------------------
 


### PR DESCRIPTION
First of all, thanks for your Material Design Icons integration, great job :-)

For my application, I need to use `QMaterialIcons` as a git submodule and then use `include()` keyword to add it on the build step.

This PR just adds `QMaterialIcons.pri` file to make this possible and adds readme's entry to explain how to use `QMaterialIcons` as a git submodule.